### PR TITLE
[CD-4555] | Handling null pointer in HttpResponse

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/http/ApacheHttpResponse.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/http/ApacheHttpResponse.java
@@ -46,7 +46,8 @@ public class ApacheHttpResponse implements HttpClient.Response {
 
   @Override
   public InputStream bodyAsStream() {
-    return new ByteArrayInputStream(response.getBodyBytes());
+    byte[] bodyBytes = response.getBodyBytes();
+    return bodyBytes != null ? new ByteArrayInputStream(bodyBytes) : null;
   }
 
   @Override


### PR DESCRIPTION
[CD-4555] | Handling null pointer in HttpResponse