### PR TITLE
CD-8147 | Track Cursor IDE Usage in the VS Code Extension

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
@@ -79,6 +79,7 @@ import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
+import static org.sonarsource.sonarlint.ls.settings.SettingsManager.*;
 import static org.sonarsource.sonarlint.ls.util.Utils.pluralize;
 
 public class AnalysisTaskExecutor {
@@ -557,7 +558,12 @@ public class AnalysisTaskExecutor {
         codescanProps.put("sonar.login", Objects.requireNonNullElse(serverConnectionSettings.getToken(), ""));
       }
     }
-    codescanProps.put("codescan.ide.type", "VSCode");
+
+    String ideType = settings.getIdeType();
+    if (!VSCODE.equals(ideType) && !CURSOR.equals(ideType)) {
+      ideType = VSCODE;
+    }
+    codescanProps.put("codescan.ide.type", ideType);
     return codescanProps;
   }
 

--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
@@ -79,7 +79,8 @@ import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
-import static org.sonarsource.sonarlint.ls.settings.SettingsManager.*;
+import static org.sonarsource.sonarlint.ls.settings.SettingsManager.VSCODE;
+import static org.sonarsource.sonarlint.ls.settings.SettingsManager.CURSOR;
 import static org.sonarsource.sonarlint.ls.util.Utils.pluralize;
 
 public class AnalysisTaskExecutor {

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -141,6 +141,7 @@ import static org.sonarsource.sonarlint.ls.CommandManager.SONARLINT_OPEN_RULE_DE
 import static org.sonarsource.sonarlint.ls.CommandManager.SONARLINT_SHOW_SECURITY_HOTSPOT_FLOWS;
 import static org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageClient.ConnectionCheckResult.failure;
 import static org.sonarsource.sonarlint.ls.SonarLintExtendedLanguageClient.ConnectionCheckResult.success;
+import static org.sonarsource.sonarlint.ls.settings.SettingsManager.IDE_TYPE;
 import static org.sonarsource.sonarlint.ls.util.Utils.hotspotStatusOfTitle;
 import static org.sonarsource.sonarlint.ls.util.Utils.hotspotStatusValueOfHotspotReviewStatus;
 
@@ -300,6 +301,8 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
         options = Collections.emptyMap();
       }
 
+      var ideType = (String) options.get(IDE_TYPE);
+      settingsManager.setIdeType(ideType);
       var productKey = (String) options.get("productKey");
       // deprecated, will be ignored when productKey present
       var telemetryStorage = (String) options.get("telemetryStorage");

--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
@@ -19,7 +19,8 @@
  */
 package org.sonarsource.sonarlint.ls.backend;
 
-import static org.sonarsource.sonarlint.ls.settings.SettingsManager.*;
+import static org.sonarsource.sonarlint.ls.settings.SettingsManager.VSCODE;
+import static org.sonarsource.sonarlint.ls.settings.SettingsManager.CURSOR;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/backend/BackendServiceFacade.java
@@ -19,6 +19,8 @@
  */
 package org.sonarsource.sonarlint.ls.backend;
 
+import static org.sonarsource.sonarlint.ls.settings.SettingsManager.*;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -101,13 +103,14 @@ public class BackendServiceFacade {
     initParams.setSonarQubeConnections(sqConnections);
     initParams.setSonarCloudConnections(scConnections);
     initParams.setStandaloneRuleConfigByKey(this.settingsManager.getStandaloneRuleConfigByKey());
-    backend.initialize(toInitParams(initParams));
+    backend.initialize(toInitParams(initParams, settingsManager.getIdeType()));
     backend.addConfigurationScopes(new DidAddConfigurationScopesParams(List.of(rootConfigurationScope)));
   }
 
-  private static InitializeParams toInitParams(BackendInitParams initParams) {
+  private static InitializeParams toInitParams(BackendInitParams initParams, String ideType) {
+    String ideName = VSCODE.equals(ideType) ? "Visual Studio Code" : CURSOR;
     return new InitializeParams(
-      new ClientInfoDto("Visual Studio Code", initParams.getTelemetryProductKey(), initParams.getUserAgent()),
+      new ClientInfoDto(ideName, initParams.getTelemetryProductKey(), initParams.getUserAgent()),
       new FeatureFlagsDto(true, true, true, true, initParams.isEnableSecurityHotspots()),
       initParams.getStorageRoot(),
       null,

--- a/src/main/java/org/sonarsource/sonarlint/ls/settings/SettingsManager.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/settings/SettingsManager.java
@@ -77,6 +77,10 @@ public class SettingsManager implements WorkspaceFolderLifecycleListener {
   private static final String SHOW_VERBOSE_LOGS = "showVerboseLogs";
   private static final String PATH_TO_NODE_EXECUTABLE = "pathToNodeExecutable";
   private static final String PATH_TO_COMPILE_COMMANDS = "pathToCompileCommands";
+  public static final String IDE_TYPE = "ideType";
+  public static final String VSCODE = "VSCode";
+  public static final String CURSOR = "Cursor";
+  private String ideType;
 
   private static final String WORKSPACE_FOLDER_VARIABLE = "${workspaceFolder}";
 
@@ -126,6 +130,18 @@ public class SettingsManager implements WorkspaceFolderLifecycleListener {
       interrupted(e);
     }
     throw new IllegalStateException("Unable to get settings in time");
+  }
+
+  public void setIdeType(@Nullable String ideType) {
+    if (CURSOR.equals(ideType) || VSCODE.equals(ideType)) {
+      this.ideType = ideType;
+    } else {
+      this.ideType = VSCODE;
+    }
+  }
+
+  public String getIdeType() {
+    return ideType;
   }
 
   public Map<String, StandaloneRuleConfigDto> getStandaloneRuleConfigByKey() {
@@ -392,6 +408,7 @@ public class SettingsManager implements WorkspaceFolderLifecycleListener {
     var analyzerProperties = (Map<String, String>) params.getOrDefault(ANALYZER_PROPERTIES, Map.of());
     String connectionId = null;
     String projectKey = null;
+    String detectedIdeType = getIdeType();
     @SuppressWarnings("unchecked")
     var connectedModeMap = (Map<String, Object>) params.getOrDefault("connectedMode", Collections.emptyMap());
     if (connectedModeMap.containsKey(PROJECT)) {
@@ -417,7 +434,8 @@ public class SettingsManager implements WorkspaceFolderLifecycleListener {
       }
     }
     pathToCompileCommands = substituteWorkspaceFolderVariable(workspaceFolderUri, pathToCompileCommands);
-    return new WorkspaceFolderSettings(connectionId, projectKey, analyzerProperties, testFilePattern, pathToCompileCommands);
+    return new WorkspaceFolderSettings(connectionId, projectKey, analyzerProperties, testFilePattern, pathToCompileCommands,
+            detectedIdeType);
   }
 
   @CheckForNull

--- a/src/main/java/org/sonarsource/sonarlint/ls/settings/WorkspaceFolderSettings.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/settings/WorkspaceFolderSettings.java
@@ -45,14 +45,21 @@ public class WorkspaceFolderSettings {
   private final String connectionId;
   private final String projectKey;
   private final String pathToCompileCommands;
+  private final String ideType;
+
+  public WorkspaceFolderSettings(@Nullable String connectionId, @Nullable String projectKey, Map<String, String> analyzerProperties,
+    @Nullable String testFilePattern, @Nullable String pathToCompileCommands) {
+    this(connectionId, projectKey, analyzerProperties, testFilePattern, pathToCompileCommands, null);
+  }
 
   public WorkspaceFolderSettings(@Nullable String connectionId, @Nullable String projectKey, Map<String, String> analyzerProperties, @Nullable String testFilePattern,
-    @Nullable String pathToCompileCommands) {
+    @Nullable String pathToCompileCommands, @Nullable String ideType) {
     this.connectionId = connectionId;
     this.projectKey = projectKey;
     this.analyzerProperties = analyzerProperties;
     this.testFilePattern = testFilePattern;
     this.pathToCompileCommands = pathToCompileCommands;
+    this.ideType = ideType;
     this.testMatcher = testFilePattern != null ? FileSystems.getDefault().getPathMatcher("glob:" + testFilePattern) : (p -> false);
   }
 
@@ -79,13 +86,18 @@ public class WorkspaceFolderSettings {
     return projectKey;
   }
 
+  @CheckForNull
+  public String getIdeType() {
+    return ideType;
+  }
+
   public boolean hasBinding() {
     return StringUtils.isNotBlank(connectionId) && StringUtils.isNotBlank(projectKey);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(connectionId, projectKey, analyzerProperties, testFilePattern, pathToCompileCommands);
+    return Objects.hash(connectionId, projectKey, analyzerProperties, testFilePattern, pathToCompileCommands, ideType);
   }
 
   @Override
@@ -101,7 +113,7 @@ public class WorkspaceFolderSettings {
     }
     var other = (WorkspaceFolderSettings) obj;
     return Objects.equals(connectionId, other.connectionId) && Objects.equals(projectKey, other.projectKey) && Objects.equals(analyzerProperties, other.analyzerProperties)
-      && Objects.equals(testFilePattern, other.testFilePattern) && Objects.equals(pathToCompileCommands, other.pathToCompileCommands);
+      && Objects.equals(testFilePattern, other.testFilePattern) && Objects.equals(pathToCompileCommands, other.pathToCompileCommands) && Objects.equals(ideType, other.ideType);
   }
 
   @Override


### PR DESCRIPTION
Implement to capture and view Cursor IDE usage details (User Name, IDE Type = Cursor, Timestamp) within CodeScan Cloud,
so that customer can understand IDE adoption, user activity, and engagement trends alongside existing usage data.