### PR TITLE
CD-8286 | Enable Configurable Cross-File Analysis in IDE Extension

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisClientInputFile.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisClientInputFile.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
@@ -38,13 +39,15 @@ public class AnalysisClientInputFile implements ClientInputFile {
   private final Language sqLanguage;
   private final String relativePath;
   private final boolean isTest;
+  private final List<ClientInputFile> dependencyFiles;;
 
-  public AnalysisClientInputFile(URI uri, String relativePath, String content, boolean isTest, @Nullable String clientLanguageId) {
+  public AnalysisClientInputFile(URI uri, String relativePath, String content, boolean isTest, @Nullable String clientLanguageId, List<ClientInputFile> dependencyFiles) {
     this.relativePath = relativePath;
     this.fileUri = uri;
     this.content = content;
     this.isTest = isTest;
     this.sqLanguage = toSqLanguage(clientLanguageId);
+    this.dependencyFiles = dependencyFiles;
   }
 
   @Override
@@ -128,5 +131,9 @@ public class AnalysisClientInputFile implements ClientInputFile {
         // Other supported languages map to the same key as the one used in CodeScan
         return Language.forKey(clientLanguageId).orElse(null);
     }
+  }
+  @Override
+  public List<ClientInputFile> getDependencyFiles(){
+    return this.dependencyFiles;
   }
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisClientInputFile.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisClientInputFile.java
@@ -39,15 +39,15 @@ public class AnalysisClientInputFile implements ClientInputFile {
   private final Language sqLanguage;
   private final String relativePath;
   private final boolean isTest;
-  private final List<ClientInputFile> dependencyFiles;;
+  private final List<ClientInputFile> referenceFiles;;
 
-  public AnalysisClientInputFile(URI uri, String relativePath, String content, boolean isTest, @Nullable String clientLanguageId, List<ClientInputFile> dependencyFiles) {
+  public AnalysisClientInputFile(URI uri, String relativePath, String content, boolean isTest, @Nullable String clientLanguageId, List<ClientInputFile> referenceFiles) {
     this.relativePath = relativePath;
     this.fileUri = uri;
     this.content = content;
     this.isTest = isTest;
     this.sqLanguage = toSqLanguage(clientLanguageId);
-    this.dependencyFiles = dependencyFiles;
+    this.referenceFiles = referenceFiles;
   }
 
   @Override
@@ -133,7 +133,7 @@ public class AnalysisClientInputFile implements ClientInputFile {
     }
   }
   @Override
-  public List<ClientInputFile> getDependencyFiles(){
-    return this.dependencyFiles;
+  public List<ClientInputFile> getReferenceFiles(){
+    return this.referenceFiles;
   }
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -543,8 +544,24 @@ public class AnalysisTaskExecutor {
       .addInputFiles(
         new AnalysisClientInputFile(uri, FileUtils.getFileRelativePath(baseDir, uri), openFile.getContent(),
           fileTypeClassifier.isTest(settings, uri, openFile.isJava(), () -> ofNullable(javaConfigs.get(uri))),
-          openFile.getLanguageId())));
+          openFile.getLanguageId(), buildDependencyInputFiles(openFile,baseDir,settings,javaConfigs))));
     return configurationBuilder;
+  }
+
+  private List<ClientInputFile> buildDependencyInputFiles(VersionedOpenFile openFile, Path baseDir, WorkspaceFolderSettings settings, Map<URI, GetJavaConfigResponse> javaConfigs) {
+    List<VersionedOpenFile> dependencies = openFile.getDependencyFiles();
+    if (dependencies == null) {
+      return null;
+    }
+
+    List<ClientInputFile> dependencyInputFiles = new LinkedList<>();
+    for (var dependency : dependencies) {
+       dependencyInputFiles.add(new AnalysisClientInputFile(dependency.getUri(),
+               FileUtils.getFileRelativePath(baseDir, dependency.getUri()), dependency.getContent(),
+               fileTypeClassifier.isTest(settings, dependency.getUri(), dependency.isJava(),
+                      () -> ofNullable(javaConfigs.get(dependency.getUri()))), dependency.getLanguageId(), null));
+    }
+    return dependencyInputFiles;
   }
 
   private Map<String, String> getCodeScanProperties(WorkspaceFolderSettings settings) {

--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
@@ -376,8 +376,10 @@ public class AnalysisTaskExecutor {
         checkCanceled(task, progressFacade);
         filesSuccessfullyAnalyzed.remove(fileUri);
         var file = filesToAnalyze.get(fileUri);
-        issuesCache.analysisFailed(file);
-        securityHotspotsCache.analysisFailed(file);
+        if (file != null) {
+          issuesCache.analysisFailed(file);
+          securityHotspotsCache.analysisFailed(file);
+        }
       });
 
     if (!filesSuccessfullyAnalyzed.isEmpty()) {

--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
@@ -549,7 +549,7 @@ public class AnalysisTaskExecutor {
   }
 
   private List<ClientInputFile> buildDependencyInputFiles(VersionedOpenFile openFile, Path baseDir, WorkspaceFolderSettings settings, Map<URI, GetJavaConfigResponse> javaConfigs) {
-    List<VersionedOpenFile> dependencies = openFile.getDependencyFiles();
+    List<VersionedOpenFile> dependencies = openFile.getReferenceFiles();
     if (dependencies == null) {
       return null;
     }

--- a/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/AnalysisTaskExecutor.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -554,7 +553,7 @@ public class AnalysisTaskExecutor {
       return null;
     }
 
-    List<ClientInputFile> dependencyInputFiles = new LinkedList<>();
+    List<ClientInputFile> dependencyInputFiles = new ArrayList<>(dependencies.size());
     for (var dependency : dependencies) {
        dependencyInputFiles.add(new AnalysisClientInputFile(dependency.getUri(),
                FileUtils.getFileRelativePath(baseDir, dependency.getUri()), dependency.getContent(),

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
@@ -558,19 +558,19 @@ public interface SonarLintExtendedLanguageServer extends LanguageServer {
 
   class CrossFileAnalysisParams {
     private final TextDocumentItem fileOpened;
-    private final List<TextDocumentItem> dependencyFiles;
+    private final List<TextDocumentItem> referenceFiles;
 
-    public CrossFileAnalysisParams(TextDocumentItem fileOpened, List<TextDocumentItem> dependencyFiles) {
+    public CrossFileAnalysisParams(TextDocumentItem fileOpened, List<TextDocumentItem> referenceFiles) {
       this.fileOpened = fileOpened;
-      this.dependencyFiles = dependencyFiles;
+      this.referenceFiles = referenceFiles;
     }
 
     public TextDocumentItem getFileOpened() {
       return fileOpened;
     }
 
-    public List<TextDocumentItem> getDependencyFiles() {
-      return dependencyFiles;
+    public List<TextDocumentItem> getReferenceFiles() {
+      return referenceFiles;
     }
   }
   @JsonNotification("codescan/didOpenWithCrossFileAnalysis")

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
@@ -553,7 +553,7 @@ public interface SonarLintExtendedLanguageServer extends LanguageServer {
       return fileUri;
     }
   }
-  @JsonNotification("codescan/checkIfCrossFileAnalysisIsEnabled")
+  @JsonRequest("codescan/checkIfCrossFileAnalysisIsEnabled")
   CompletableFuture<Map<String, Boolean>> checkIfCrossFileAnalysisIsEnabled(FileParam params);
 
   class CrossFileAnalysisParams {

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
@@ -577,6 +577,6 @@ public interface SonarLintExtendedLanguageServer extends LanguageServer {
   void didOpenWithCrossFileAnalysis(CrossFileAnalysisParams params);
   @JsonNotification("codescan/didChangeWithCrossFileAnalysis")
   void didChangeWithCrossFileAnalysis(CrossFileAnalysisParams params);
-  @JsonRequest("codescan/getAvailableCrossFileRuleKey")
-  CompletableFuture<Map<String, String>> getAvailableCrossFileAnalysisRuleKey(FileParam params);
+  @JsonNotification("codescan/logCrossFileAnalysisLimitExceeded")
+  void logCrossFileAnalysisLimitExceeded(FileParam param);
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
@@ -577,4 +577,6 @@ public interface SonarLintExtendedLanguageServer extends LanguageServer {
   void didOpenWithCrossFileAnalysis(CrossFileAnalysisParams params);
   @JsonNotification("codescan/didChangeWithCrossFileAnalysis")
   void didChangeWithCrossFileAnalysis(CrossFileAnalysisParams params);
+  @JsonRequest("codescan/getAvailableCrossFileRuleKey")
+  CompletableFuture<Map<String, String>> getAvailableCrossFileAnalysisRuleKey(FileParam params);
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
@@ -542,4 +542,17 @@ public interface SonarLintExtendedLanguageServer extends LanguageServer {
   }
   @JsonRequest("codescan/checkIfConnectionIsCloud")
   CompletableFuture<Map<String, Boolean>> checkIfConnectionIsCloud(CheckIfCloudConnectionParams params);
+  class FileParam{
+    private final String fileUri;
+
+    public FileParam(String fileUri) {
+      this.fileUri = fileUri;
+    }
+
+    public String getFileUri() {
+      return fileUri;
+    }
+  }
+  @JsonNotification("codescan/checkIfCrossFileAnalysisIsEnabled")
+  CompletableFuture<Map<String, Boolean>> checkIfCrossFileAnalysisIsEnabled(FileParam params);
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintExtendedLanguageServer.java
@@ -555,4 +555,26 @@ public interface SonarLintExtendedLanguageServer extends LanguageServer {
   }
   @JsonNotification("codescan/checkIfCrossFileAnalysisIsEnabled")
   CompletableFuture<Map<String, Boolean>> checkIfCrossFileAnalysisIsEnabled(FileParam params);
+
+  class CrossFileAnalysisParams {
+    private final TextDocumentItem fileOpened;
+    private final List<TextDocumentItem> dependencyFiles;
+
+    public CrossFileAnalysisParams(TextDocumentItem fileOpened, List<TextDocumentItem> dependencyFiles) {
+      this.fileOpened = fileOpened;
+      this.dependencyFiles = dependencyFiles;
+    }
+
+    public TextDocumentItem getFileOpened() {
+      return fileOpened;
+    }
+
+    public List<TextDocumentItem> getDependencyFiles() {
+      return dependencyFiles;
+    }
+  }
+  @JsonNotification("codescan/didOpenWithCrossFileAnalysis")
+  void didOpenWithCrossFileAnalysis(CrossFileAnalysisParams params);
+  @JsonNotification("codescan/didChangeWithCrossFileAnalysis")
+  void didChangeWithCrossFileAnalysis(CrossFileAnalysisParams params);
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -897,8 +897,8 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
     var uri = create(params.getFileOpened().getUri());
     client.isOpenInEditor(uri.toString()).thenAccept(isOpen -> {
     if (Boolean.TRUE.equals(isOpen)) {
-       var filesToAnalyze = toDependencyFiles(params.getDependencyFiles());
-       var file = openFilesCache.didOpenWithCrossFile(uri, params.getFileOpened().getLanguageId(), params.getFileOpened().getText(), params.getFileOpened().getVersion(), filesToAnalyze);
+       var referenceFiles = toReferenceFiles(params.getDependencyFiles());
+       var file = openFilesCache.didOpenWithCrossFile(uri, params.getFileOpened().getLanguageId(), params.getFileOpened().getText(), params.getFileOpened().getVersion(), referenceFiles);
        analysisScheduler.didOpen(file);
        taintIssuesUpdater.updateTaintIssuesAsync(uri);
     } else {
@@ -908,13 +908,13 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
   }
   @Override
   public void didChangeWithCrossFileAnalysis(CrossFileAnalysisParams params) {
-    var filesToAnalyze = toDependencyFiles(params.getDependencyFiles());
+    var referenceFiles = toReferenceFiles(params.getDependencyFiles());
     var uri = create(params.getFileOpened().getUri());
-    openFilesCache.didChangeWithCrossFile(uri, params.getFileOpened().getText(), params.getFileOpened().getVersion(), filesToAnalyze);
+    openFilesCache.didChangeWithCrossFile(uri, params.getFileOpened().getText(), params.getFileOpened().getVersion(), referenceFiles);
     analysisScheduler.didChange(uri);
   }
-  private List<VersionedOpenFile> toDependencyFiles(List<TextDocumentItem> documents) {
-    if( documents == null) return null;
+  private List<VersionedOpenFile> toReferenceFiles(List<TextDocumentItem> documents) {
+    if (documents == null) return null;
     return documents.stream()
               .map(d -> new VersionedOpenFile(create(d.getUri()), d.getLanguageId(), d.getVersion(), d.getText()))
               .collect(Collectors.toList());

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -71,6 +71,7 @@ import org.eclipse.lsp4j.NotebookSelectorCell;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.ServerInfo;
 import org.eclipse.lsp4j.SetTraceParams;
+import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextDocumentSyncOptions;
 import org.eclipse.lsp4j.WorkDoneProgressCancelParams;
@@ -890,5 +891,36 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
     } catch (RuntimeException e) {
       return CompletableFuture.completedFuture(Map.of("isCrossFileAnalysisEnabled", false));
     }
+  }
+  @Override
+  public void didOpenWithCrossFileAnalysis(CrossFileAnalysisParams params) {
+    var uri = create(params.getFileOpened().getUri());
+    client.isOpenInEditor(uri.toString()).thenAccept(isOpen -> {
+    if (Boolean.TRUE.equals(isOpen)) {
+         // var parent = params.getFileOpened();
+       var filesToAnalyze = toDependencyFiles(params.getDependencyFiles());
+       //   var parentFile =  new VersionedOpenFile(create(parent.getUri()), parent.getLanguageId(), parent.getVersion(), parent.getText(), filesToAnalyze);
+       var file = openFilesCache.didOpenWithCrossFile(uri, params.getFileOpened().getLanguageId(), params.getFileOpened().getText(), params.getFileOpened().getVersion(), filesToAnalyze);
+       analysisScheduler.didOpen(file);
+       taintIssuesUpdater.updateTaintIssuesAsync(uri);
+    } else {
+         SonarLintLogger.get().debug("Skipping analysis for preview of file {}", uri);
+    }
+    });
+  }
+  @Override
+  public void didChangeWithCrossFileAnalysis(CrossFileAnalysisParams params) {
+    var parent = params.getFileOpened();
+    var filesToAnalyze = toDependencyFiles(params.getDependencyFiles());
+    //var parentFile =  new VersionedOpenFile(create(parent.getUri()), parent.getLanguageId(), parent.getVersion(), parent.getText(), filesToAnalyze);
+    var uri = create(params.getFileOpened().getUri());
+    openFilesCache.didChangeWithCrossFile(uri, params.getFileOpened().getText(), params.getFileOpened().getVersion(), filesToAnalyze);
+    analysisScheduler.didChange(uri);
+  }
+  private List<VersionedOpenFile> toDependencyFiles(List<TextDocumentItem> documents) {
+    if( documents == null) return null;
+    return documents.stream()
+              .map(d -> new VersionedOpenFile(create(d.getUri()), d.getLanguageId(), d.getVersion(), d.getText()))
+              .collect(Collectors.toList());
   }
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -919,4 +919,19 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
               .map(d -> new VersionedOpenFile(create(d.getUri()), d.getLanguageId(), d.getVersion(), d.getText()))
               .collect(Collectors.toList());
   }
+
+  @Override
+  public CompletableFuture<Map<String, String>>  getAvailableCrossFileAnalysisRuleKey(FileParam params){
+    try {
+      var binding = bindingManager.getBinding(create(params.getFileUri())).orElse(null);
+      if (binding == null) {
+              return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", ""));
+      }
+          String availableCrossFileAnalysisRuleKey = binding.getEngine().getAvailableCrossFileAnalysisRuleKey(binding.getBinding());
+          return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", availableCrossFileAnalysisRuleKey));
+      } catch (RuntimeException e) {
+          return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", ""));
+      }
+  }
+
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -897,7 +897,7 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
     var uri = create(params.getFileOpened().getUri());
     client.isOpenInEditor(uri.toString()).thenAccept(isOpen -> {
     if (Boolean.TRUE.equals(isOpen)) {
-       var referenceFiles = toReferenceFiles(params.getDependencyFiles());
+       var referenceFiles = toReferenceFiles(params.getReferenceFiles());
        var file = openFilesCache.didOpenWithCrossFile(uri, params.getFileOpened().getLanguageId(), params.getFileOpened().getText(), params.getFileOpened().getVersion(), referenceFiles);
        analysisScheduler.didOpen(file);
        taintIssuesUpdater.updateTaintIssuesAsync(uri);
@@ -908,7 +908,7 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
   }
   @Override
   public void didChangeWithCrossFileAnalysis(CrossFileAnalysisParams params) {
-    var referenceFiles = toReferenceFiles(params.getDependencyFiles());
+    var referenceFiles = toReferenceFiles(params.getReferenceFiles());
     var uri = create(params.getFileOpened().getUri());
     openFilesCache.didChangeWithCrossFile(uri, params.getFileOpened().getText(), params.getFileOpened().getVersion(), referenceFiles);
     analysisScheduler.didChange(uri);

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -925,13 +925,13 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
     try {
       var binding = bindingManager.getBinding(create(params.getFileUri())).orElse(null);
       if (binding == null) {
-              return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", ""));
+        return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", ""));
       }
-          String availableCrossFileAnalysisRuleKey = binding.getEngine().getAvailableCrossFileAnalysisRuleKey(binding.getBinding());
-          return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", availableCrossFileAnalysisRuleKey));
-      } catch (RuntimeException e) {
-          return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", ""));
-      }
+      String availableCrossFileAnalysisRuleKey = binding.getEngine().getAvailableCrossFileAnalysisRuleKey(binding.getBinding());
+      return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", availableCrossFileAnalysisRuleKey));
+    } catch (RuntimeException e) {
+      return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", ""));
+    }
   }
 
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -880,11 +880,11 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
 
   @Override
   public CompletableFuture<Map<String, Boolean>> checkIfCrossFileAnalysisIsEnabled(FileParam params) {
-    var binding = bindingManager.getBinding(create(params.getFileUri())).orElse(null);
-    if (binding == null) {
-      return CompletableFuture.completedFuture(Map.of("isCrossFileAnalysisEnabled", false));
-    }
     try {
+      var binding = bindingManager.getBinding(create(params.getFileUri())).orElse(null);
+      if (binding == null) {
+        return CompletableFuture.completedFuture(Map.of("isCrossFileAnalysisEnabled", false));
+      }
       boolean isEnabled = binding.getEngine().checkIfCrossFileAnalysisIsEnabled(binding.getBinding());
       return CompletableFuture.completedFuture(Map.of("isCrossFileAnalysisEnabled", isEnabled));
     } catch (RuntimeException e) {

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -921,16 +921,21 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
   }
 
   @Override
-  public CompletableFuture<Map<String, String>>  getAvailableCrossFileAnalysisRuleKey(FileParam params){
+  public void logCrossFileAnalysisLimitExceeded(FileParam param) {
+    lsLogOutput.warn(String.format(
+         "Rule '%s': Reference file limit reached. Results may be less accurate. Increase the limit for better accuracy or reduce it for faster analysis.",
+           getAvailableCrossFileAnalysisRuleKeyFrom(param)));
+  }
+
+  private String  getAvailableCrossFileAnalysisRuleKeyFrom(FileParam params){
     try {
       var binding = bindingManager.getBinding(create(params.getFileUri())).orElse(null);
       if (binding == null) {
-        return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", ""));
+        return "";
       }
-      String availableCrossFileAnalysisRuleKey = binding.getEngine().getAvailableCrossFileAnalysisRuleKey(binding.getBinding());
-      return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", availableCrossFileAnalysisRuleKey));
+      return binding.getEngine().getAvailableCrossFileAnalysisRuleKey(binding.getBinding());
     } catch (RuntimeException e) {
-      return CompletableFuture.completedFuture(Map.of("crossFileAnalysisRuleKey", ""));
+      return "";
     }
   }
 

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -897,9 +897,7 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
     var uri = create(params.getFileOpened().getUri());
     client.isOpenInEditor(uri.toString()).thenAccept(isOpen -> {
     if (Boolean.TRUE.equals(isOpen)) {
-         // var parent = params.getFileOpened();
        var filesToAnalyze = toDependencyFiles(params.getDependencyFiles());
-       //   var parentFile =  new VersionedOpenFile(create(parent.getUri()), parent.getLanguageId(), parent.getVersion(), parent.getText(), filesToAnalyze);
        var file = openFilesCache.didOpenWithCrossFile(uri, params.getFileOpened().getLanguageId(), params.getFileOpened().getText(), params.getFileOpened().getVersion(), filesToAnalyze);
        analysisScheduler.didOpen(file);
        taintIssuesUpdater.updateTaintIssuesAsync(uri);
@@ -910,9 +908,7 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
   }
   @Override
   public void didChangeWithCrossFileAnalysis(CrossFileAnalysisParams params) {
-    var parent = params.getFileOpened();
     var filesToAnalyze = toDependencyFiles(params.getDependencyFiles());
-    //var parentFile =  new VersionedOpenFile(create(parent.getUri()), parent.getLanguageId(), parent.getVersion(), parent.getText(), filesToAnalyze);
     var uri = create(params.getFileOpened().getUri());
     openFilesCache.didChangeWithCrossFile(uri, params.getFileOpened().getText(), params.getFileOpened().getVersion(), filesToAnalyze);
     analysisScheduler.didChange(uri);

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -924,10 +924,10 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
   public void logCrossFileAnalysisLimitExceeded(FileParam param) {
     lsLogOutput.warn(String.format(
          "Rule '%s': Reference file limit reached. Results may be less accurate. Increase the limit for better accuracy or reduce it for faster analysis.",
-           getAvailableCrossFileAnalysisRuleKeyFrom(param)));
+           getAvailableCrossFileAnalysisRuleKey(param)));
   }
 
-  private String  getAvailableCrossFileAnalysisRuleKeyFrom(FileParam params){
+  private String  getAvailableCrossFileAnalysisRuleKey(FileParam params){
     try {
       var binding = bindingManager.getBinding(create(params.getFileUri())).orElse(null);
       if (binding == null) {

--- a/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/SonarLintLanguageServer.java
@@ -877,4 +877,18 @@ public class SonarLintLanguageServer implements SonarLintExtendedLanguageServer,
             && SonarCloudConnectionConfiguration.isCodeScanCloudAlias(params.getUrl());
     return CompletableFuture.completedFuture(Map.of("isCloudConnection", isCloudConnection));
   }
+
+  @Override
+  public CompletableFuture<Map<String, Boolean>> checkIfCrossFileAnalysisIsEnabled(FileParam params) {
+    var binding = bindingManager.getBinding(create(params.getFileUri())).orElse(null);
+    if (binding == null) {
+      return CompletableFuture.completedFuture(Map.of("isCrossFileAnalysisEnabled", false));
+    }
+    try {
+      boolean isEnabled = binding.getEngine().checkIfCrossFileAnalysisIsEnabled(binding.getBinding());
+      return CompletableFuture.completedFuture(Map.of("isCrossFileAnalysisEnabled", isEnabled));
+    } catch (RuntimeException e) {
+      return CompletableFuture.completedFuture(Map.of("isCrossFileAnalysisEnabled", false));
+    }
+  }
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/file/OpenFilesCache.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/file/OpenFilesCache.java
@@ -21,6 +21,7 @@ package org.sonarsource.sonarlint.ls.file;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,11 +65,38 @@ public class OpenFilesCache {
     return file;
   }
 
+  /**
+   * 'aura components' vs-code extension sets languageId as html for aura-components with file extensions ->
+   * .app, .cmp, .design, .evt, .intf, .auradoc or .tokens
+   * reset languageId as visualforce for these aura components
+   */
+  public VersionedOpenFile didOpenWithCrossFile(URI fileUri, String languageId, String fileContent, int version, List<VersionedOpenFile> childrens) {
+    var file = new VersionedOpenFile(fileUri, languageId, version, fileContent, childrens);
+    openFilesPerFileURI.put(fileUri, file);
+
+    // Detect VF files if HTML
+    if (languageId.equals("html")) {
+      for (var fileSuffix : Language.VF.getDefaultFileSuffixes()) {
+        if (fileUri.getPath().endsWith(fileSuffix)) {
+          var vfFile = new VersionedOpenFile(fileUri, "visualforce", version, fileContent);
+          openFilesPerFileURI.put(fileUri, vfFile);
+          break;
+        }
+      }
+    }
+    return file;
+ }
   public void didChange(URI fileUri, String fileContent, int version) {
     if (!openFilesPerFileURI.containsKey(fileUri)) {
       lsLogOutput.warn(format("Illegal state. File '%s' is reported changed but we missed the open notification", fileUri));
     }
     openFilesPerFileURI.computeIfPresent(fileUri, (uri, previous) -> new VersionedOpenFile(uri, previous.getLanguageId(), version, fileContent));
+  }
+  public void didChangeWithCrossFile(URI fileUri, String fileContent, int version, List<VersionedOpenFile> childrens) {
+    if (!openFilesPerFileURI.containsKey(fileUri)) {
+      lsLogOutput.warn(format("Illegal state. File '%s' is reported changed but we missed the open notification", fileUri));
+    }
+    openFilesPerFileURI.computeIfPresent(fileUri, (uri, previous) -> new VersionedOpenFile(uri, previous.getLanguageId(), version, fileContent, childrens));
   }
 
   public void didClose(URI fileUri) {

--- a/src/main/java/org/sonarsource/sonarlint/ls/file/VersionedOpenFile.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/file/VersionedOpenFile.java
@@ -20,6 +20,7 @@
 package org.sonarsource.sonarlint.ls.file;
 
 import java.net.URI;
+import java.util.List;
 import javax.annotation.concurrent.Immutable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
@@ -32,12 +33,16 @@ public class VersionedOpenFile {
   private final String languageId;
   private final int version;
   private final String content;
-
+  private List<VersionedOpenFile> dependencyFiles;
   public VersionedOpenFile(URI uri, String languageId, int version, String content) {
     this.uri = uri;
     this.languageId = languageId;
     this.version = version;
     this.content = content;
+  }
+  public VersionedOpenFile(URI uri, String languageId, int version, String content, List<VersionedOpenFile> dependencyFiles) {
+    this(uri, languageId,version,content);
+    this.dependencyFiles = dependencyFiles;
   }
 
   public URI getUri() {
@@ -69,4 +74,7 @@ public class VersionedOpenFile {
     return "c".equals(languageId) || "cpp".equals(languageId);
   }
 
+  public List<VersionedOpenFile> getDependencyFiles() {
+    return dependencyFiles;
+  }
 }

--- a/src/main/java/org/sonarsource/sonarlint/ls/file/VersionedOpenFile.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/file/VersionedOpenFile.java
@@ -33,16 +33,16 @@ public class VersionedOpenFile {
   private final String languageId;
   private final int version;
   private final String content;
-  private List<VersionedOpenFile> dependencyFiles;
+  private List<VersionedOpenFile> referenceFiles;
   public VersionedOpenFile(URI uri, String languageId, int version, String content) {
     this.uri = uri;
     this.languageId = languageId;
     this.version = version;
     this.content = content;
   }
-  public VersionedOpenFile(URI uri, String languageId, int version, String content, List<VersionedOpenFile> dependencyFiles) {
+  public VersionedOpenFile(URI uri, String languageId, int version, String content, List<VersionedOpenFile> referenceFiles) {
     this(uri, languageId,version,content);
-    this.dependencyFiles = dependencyFiles;
+    this.referenceFiles = referenceFiles;
   }
 
   public URI getUri() {
@@ -74,7 +74,7 @@ public class VersionedOpenFile {
     return "c".equals(languageId) || "cpp".equals(languageId);
   }
 
-  public List<VersionedOpenFile> getDependencyFiles() {
-    return dependencyFiles;
+  public List<VersionedOpenFile> getReferenceFiles() {
+    return referenceFiles;
   }
 }

--- a/src/test/java/org/sonarsource/sonarlint/ls/AnalysisClientInputFileTests.java
+++ b/src/test/java/org/sonarsource/sonarlint/ls/AnalysisClientInputFileTests.java
@@ -33,7 +33,7 @@ class AnalysisClientInputFileTests {
   @ParameterizedTest(name = "Should detect {0} as {1}")
   @MethodSource("provideParametersForLanguageDetection")
   void shouldDetectLanguage(String clientLanguageId, Language expected) {
-    assertThat(new AnalysisClientInputFile(null, null, "", false, clientLanguageId).language())
+    assertThat(new AnalysisClientInputFile(null, null, "", false, clientLanguageId, null).language())
       .isEqualTo(expected);
   }
 


### PR DESCRIPTION
**As discussed with the product team, cross-file analysis may impact performance and memory usage 
while running.** 



Currently, the IDE extension performs file-wise analysis, meaning only the file that is opened or modified gets analyzed. This approach causes inaccurate or missed violations for rules that require context across multiple files (e.g., AvoidSOQLInLoops, where validation may depend on logic spread across classes or triggers).

To address this limitation:

Introduce a Project Setting in the CodeScan apllication:

Cross-File Analysis Control (default: Disabled to preserve performance).

IDE Cross file analysis-20260303-064801.png
 

Identify and tag all rules that require cross-file or full-project traversal.

If Cross-File Analysis is Enabled:

The engine should traverse all relevant files when evaluating tagged rules.

However, only violations related to the currently opened file should be displayed in the IDE.

Violations found in other files during traversal should not be shown in the IDE panel.

Scan Optimization Rules:

If a class file is opened → analyze all class files first, then remaining files if needed.

If cross-file-required rules are not present in the active Quality Profile, skip full project traversal entirely.

Ensure traversal is rule-aware and profile-aware to prevent unnecessary scanning.

Hypothesis
If cross-file analysis is made configurable and rule-aware, the IDE extension will:

Provide more accurate detection for interdependent rules.

Maintain performance efficiency by scanning only when required.

Prevent developer distraction by limiting displayed violations to the active file.

Reduce unnecessary full-project scans when cross-file rules are not active in the Quality Profile.

Value / Purpose
Improved Rule Accuracy – Enables correct evaluation of cross-dependent rules like AvoidSOQLInLoops.

Developer Experience – Keeps IDE feedback focused on the current file, avoiding noise.

Performance Optimization – Conditional traversal reduces unnecessary scans.

Acceptance Criteria


Introduce a Project Setting in the CodeScan apllication:

Cross-File Analysis Control (default: Disabled to preserve performance).

IDE Cross file analysis-20260303-064801.png
Add Note: “Note: After enabling or disabling this setting, CodeScan project bindings must be updated again in the IDE.“

Identify and tag all rules that require cross-file or full-project traversal.

If Cross-File Analysis is Enabled:

The engine should traverse all relevant files when evaluating tagged rules.

However, only violations related to the currently opened file should be displayed in the IDE.

Violations found in other files during traversal should not be shown in the IDE panel.

Scan Optimization Rules:

If a class file is opened → analyze all class files first, then remaining files if needed.

If cross-file-required rules are not present in the active Quality Profile, skip full project traversal entirely.

Ensure traversal is rule-aware and profile-aware to prevent unnecessary scanning.